### PR TITLE
Feature: use env `WRAPPED_PREPEND_IF` to control the condition of prepending arguments in env `WRAPPED_PREPEND_ARGS`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2021"
 
 [dependencies]
 git-version = "0.3.5"
+regex = "1.5.5"

--- a/src/main.rs
+++ b/src/main.rs
@@ -81,11 +81,15 @@ fn remove_dup_args(args: &Vec<String>) -> Vec<String> {
     return new_arg_list;
 }
 
-fn check_prepend_if(origin_args: &Vec<String>) -> Result<bool, regex::Error> {
+fn check_prepend_if(debug: bool, origin_args: &Vec<String>) -> Result<bool, regex::Error> {
     // check prepend condition
     let prepend_if_env = load_env("WRAPPED_PREPEND_IF", "");
     if prepend_if_env == "" {
         return Ok(true);
+    }
+
+    if debug {
+        println!("cmd-wrapper: the regex: `{}`", prepend_if_env);
     }
 
     let formatted = format!(r"{}", prepend_if_env);
@@ -104,10 +108,10 @@ fn check_prepend_if(origin_args: &Vec<String>) -> Result<bool, regex::Error> {
     return Ok(false);
 }
 
-fn parse_prepend_args_env(origin_args: &Vec<String>) -> Vec<String> {
+fn parse_prepend_args_env(debug: bool, origin_args: &Vec<String>) -> Vec<String> {
     let prepend_args_env = load_env("WRAPPED_PREPEND_ARGS", "");
     if prepend_args_env != "" {
-        match check_prepend_if(origin_args) {
+        match check_prepend_if(debug, origin_args) {
             Ok(ok) => {
                 if ok {
                     let prepend_args: Vec<&str> = prepend_args_env.split(':').collect();
@@ -126,7 +130,7 @@ fn parse_prepend_args_env(origin_args: &Vec<String>) -> Vec<String> {
 
 fn pass_by(debug: bool, args: Vec<String>) -> i32 {
     let removed_args_in_vec: Vec<String> = remove_dup_args(&args);
-    let prepend_args_in_vec: Vec<String> = parse_prepend_args_env(&args);
+    let prepend_args_in_vec: Vec<String> = parse_prepend_args_env(debug, &args);
     let new_args: Vec<String> = if prepend_args_in_vec.len() != 0 {
         // if prepend is set, use it.
         cat(&*prepend_args_in_vec, &*removed_args_in_vec)
@@ -135,7 +139,7 @@ fn pass_by(debug: bool, args: Vec<String>) -> i32 {
     };
 
     if debug {
-        println!("full arguments: {:?}", new_args);
+        println!("cmd-wrapper: full arguments: {:?}", new_args);
     }
 
     // read main program from env.


### PR DESCRIPTION

**Prepending condition**:
we can also use env `WRAPPED_PREPEND_IF` to control the condition
of adding arguments specified by `WRAPPED_PREPEND_ARGS`.  
The detailed rules are listed as following:
- If `WRAPPED_PREPEND_ARGS` is specified, it must be a string of regex expression.
  The regex is matched with the origin arguments list. 
  If at least one argument matches the regex, the prepending condition will be set to true 
  and cmd-wrapper will prepend arguments specified by env `WRAPPED_PREPEND_ARGS` to the origin arguments list.
- If env `WRAPPED_PREPEND_IF` is empty, the prepending condition would always be set to true.
  (always prepending arguments in `WRAPPED_PREPEND_ARGS` into the origin arguments list.)
e.g. 

```bash
## the origin arguments list matches the regex in ${WRAPPED_PREPEND_IF}.
WRAPPED_CMD=clang++ WRAPPED_PREPEND_ARGS=-g:-O2 \
  WRAPPED_PREPEND_IF="(\w+)\.cc\$" cmd-wrapper main.cc -o main
# => clang++ -g -O2 main.cc -o main
```
```bash
## the origin arguments list does not match the regex in ${WRAPPED_PREPEND_IF}.
WRAPPED_CMD=clang++ WRAPPED_PREPEND_ARGS=-g:-O2 \
  WRAPPED_PREPEND_IF="(\w+)\.cc\$" cmd-wrapper main.cpp -o main
# =>  clang++ main.cpp -o main
```