### PR TITLE
ci(github-action): bump action upload-artifact, download-artifact to v4 and action-gh-release to v2

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,7 +21,7 @@ jobs:
       run: cargo build --release
 
     - name: Archive production artifacts
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v4
       with:
         name: cmd-wrapper-linux-amd64
         path: target/release/cmd-wrapper
@@ -31,14 +31,14 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v4
         with:
           name: cmd-wrapper-linux-amd64
       - run: ls -R
       - run: mv cmd-wrapper cmd-wrapper-linux-amd64
 
       - name: Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         if: startsWith(github.ref, 'refs/tags/')
         with:
           files: |


### PR DESCRIPTION
ote: v1 and v2 of the artifact actions is deprecated in 2024/03. We must use the new version of artifact actions.